### PR TITLE
Leverage Nix on GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,8 +22,5 @@ jobs:
         with:
           skip_adding_nixpkgs_channel: true
 
-      - name: "Check formatting 📝"
-        run: nix-shell --run "mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources"
-
       - name: "Compile with ${{ matrix.java }} 🚀"
         run: nix-shell --argstr jdk "${{ matrix.java }}" --run "mill root.compile"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,18 +9,21 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        java:
+          - jdk11
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11.0.9
-    - name: Set up Mill
-      uses: jodersky/setup-mill@master
-      with:
-        mill-version: 0.9.3
-    - name: Check formatting
-      run: mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources
-    - name: Compile
-      run: mill root.compile
+      - uses: actions/checkout@v2.3.2
+
+      - name: "Install Nix ❄️"
+        uses: cachix/install-nix-action@v12
+        with:
+          skip_adding_nixpkgs_channel: true
+
+      - name: "Check formatting 📝"
+        run: nix-shell --run "mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll __.sources"
+
+      - name: "Compile with ${{ matrix.java }} 🚀"
+        run: nix-shell --argstr jdk "${{ matrix.java }}" --run "mill root.compile"

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,7 @@
+{ jdk ? "jdk11" }:
+
 let
-  jdk = pkgs.jdk11;
+  java = pkgs.${jdk};
 
   config = {
     packageOverrides = pkgs: rec {
@@ -16,7 +18,7 @@ let
             runHook preInstall
             install -Dm555 "$src" "$out/bin/.mill-wrapped"
             # can't use wrapProgram because it sets --argv0
-            makeWrapper "$out/bin/.mill-wrapped" "$out/bin/mill" --set JAVA_HOME "${jdk}"
+            makeWrapper "$out/bin/.mill-wrapped" "$out/bin/mill" --set JAVA_HOME "${java}"
             runHook postInstall
           '';
         }


### PR DESCRIPTION
I think this is one of the nicest things of having your software managed with Nix: there's no need to install software in a different way, you can use Nix on GH actions as well! Reproducibility FTW :rocket: 

I set it up using only JDK11, as the previous version, but you can add more versions such as `jdk8` or `jdk14`, to run parallel jobs for the different Java versions. A further small improvement would be to use Cachix to cache the custom derivation of `mill`.

I wrote a lot about using Nix in Scala projects here: https://github.com/gvolpe/sbt-nix.g8 (it's `sbt` biased but many things would work with `mill` too) and we plan to add Scala documentation on https://nixos.org/ at some point. 

Here's a repository example where we use Nix for similar things: https://github.com/cr-org/neutron

Keep up the good work and spread the word about Nix, people need to know! :bow: 

---

On a different note, the "Check formatting" step is currently failing on the `main` branch but the job still passes: https://github.com/zainab-ali/scala3-typed-holes/runs/1477275362